### PR TITLE
Don't use pip internal API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,10 @@
 # ----------------------------------------------------------------------------
 
 from setuptools import setup, find_packages
-import pip
 import manifesttool
 import os
 
-install_reqs = pip.req.parse_requirements('requirements.txt', session=pip.download.PipSession())
-reqs = [str(r.req) for r in install_reqs]
+reqs = list(line for line in open("./requirements.txt"))
 
 if os.name == 'nt':
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ from setuptools import setup, find_packages
 import manifesttool
 import os
 
-reqs = list(line for line in open("./requirements.txt"))
+with open('requirements.txt') as file_handle:
+    reqs = file_handle.readlines()
 
 if os.name == 'nt':
     entry_points={


### PR DESCRIPTION
pip is not supported as a module API. In fact, the developers are
actively trying to discourage everyone from using it this way. In pip
v10, the entire pip.req was moved to pip._internal.req, thus breaking
all scripts which imported it.
This commit removes the need for pip.req.parse_requirements by using
pure Python instead.

Reference: https://github.com/pypa/pip/issues/2286
Reference: https://github.com/pypa/pip/commit/95bcf8c5f6394298035a7332c441868f3b0169f4
Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>