### PR TITLE
README.md - fw-version limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ describing the update type.
         --output my.manifest.bin
     ```
 
+Please note that `fw-version` numbers can be between 0.0.2 and 999.999.999.
+
 #### `manifest-tool create-v1`
 
 Older versions of Device Management update client use manifest


### PR DESCRIPTION
Add note about `fw-version` limitations, number can be maximum 999. I.e. thus max version number for component is 999.999.999. 1st SW version must be at least 0.0.1, so 1st FW update version can be thus 0.0.2.