### PR TITLE
create.py - fw-version min/max

### DIFF
--- a/manifesttool/mtool/actions/create.py
+++ b/manifesttool/mtool/actions/create.py
@@ -91,7 +91,7 @@ class CreateAction:
             required.add_argument(
                 '-v', '--fw-version',
                 type=semantic_version_arg_factory,
-                help='Version number of the candidate image in SemVer format.',
+                help='Version number of the candidate image in SemVer format. Minimum 0.0.2, maximum 999.999.999.',
                 required=True
             )
 


### PR DESCRIPTION
Guidance on minimum and maximum fw-version parameter. 
- 1st SW version you start can be 0.0.1. Thus 1st firmware updated version be 0.0.2.
- Maximum version is 999.999.999.