### PR TITLE
Add wheel to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel>=0.36.0
 PyYAML>=4.2b1,<=5.4.1
 asn1ate>=0.5,<=0.6.0
 cryptography>=2.5,<=3.4.6


### PR DESCRIPTION
Wheel is needed for being able to generate the wheels for `pyrsistent` and `pyasn1´.