### PR TITLE
IZUMABL-444 manifest-tool-internal - PR Check fails (.tar.gz-creation)

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           python-version: '3.8'
       - run: python -m pip install wheel --user
+      - run: |
+          if: matrix.os == 'macos-latest'
+          brew install tox
       - run: python -m pip install --user tox
       - run: tox
 

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -32,9 +32,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
       - run: python -m pip install wheel --user
       - run: python -m pip install --user tox
       - run: tox
@@ -69,9 +66,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
       - run: python -m pip install wheel --user
       - run: python -m pip install --user tox
       - run: tox

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -33,7 +33,11 @@ jobs:
         with:
           python-version: '3.8'
       - run: python -m pip install wheel --user
-      - run: python -m pip install --user tox
+      - run: |
+          if: matrix.os == 'macos-latest'
+          brew install tox
+          else
+          python -m pip install --user tox
       - run: tox
       - uses: actions/upload-artifact@v3
         with:
@@ -70,7 +74,8 @@ jobs:
       - run: |
           if: matrix.os == 'macos-latest'
           brew install tox
-      - run: python -m pip install --user tox
+          else
+          python -m pip install --user tox
       - run: tox
 
       - name: Integration with slack

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,5 +1,5 @@
 name: PR-checker
-on: 
+on:
   push:
   workflow_dispatch:
 
@@ -33,11 +33,7 @@ jobs:
         with:
           python-version: '3.8'
       - run: python -m pip install wheel --user
-      - run: |
-          if: matrix.os == 'macos-latest'
-          brew install tox
-          else
-          python -m pip install --user tox
+      - run: python -m pip install --user tox
       - run: tox
       - uses: actions/upload-artifact@v3
         with:
@@ -71,11 +67,7 @@ jobs:
         with:
           python-version: '3.8'
       - run: python -m pip install wheel --user
-      - run: |
-          if: matrix.os == 'macos-latest'
-          brew install tox
-          else
-          python -m pip install --user tox
+      - run: python -m pip install --user tox
       - run: tox
 
       - name: Integration with slack

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019, macos11]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019, macos-latest]
     runs-on: ${{ matrix.os }}
     if: github.repository == 'PelionIoT/manifest-tool'
     steps:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.8'
       - run: python -m pip install wheel --user
       - run: python -m pip install --user tox
-      - run: tox
+      - run: python -m tox
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
@@ -68,7 +68,7 @@ jobs:
           python-version: '3.8'
       - run: python -m pip install wheel --user
       - run: python -m pip install --user tox
-      - run: tox
+      - run: python -m tox
 
       - name: Integration with slack
         uses: act10ns/slack@v2

--- a/tox.ini
+++ b/tox.ini
@@ -26,17 +26,16 @@ skips = B101,B404
 
 [tox]
 envlist =
-    py{37,38,39,310,311}
-    py{37,38,39,310,311}-x64
+    py{38,39,310,311}
+    py{38,39,310,311}-x64
     sdist
 
-[testenv:py{37,38,39,310,311}]
+[testenv:py{38,39,310,311}]
 platform = linux|darwin|win32
 
-[testenv:py{37,38,39,310,311}-x64]
+[testenv:py{38,39,310,311}-x64]
 platform = win64
 basepython =
-    py37-x64: python3.7-64
     py38-x64: python3.8-64
     py39-x64: python3.9-64
     py310-x64: python3.10-64

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ skip_install=True
 deps =
 # FIXME - use '{envpython} setup.py --fullname'
 setenv =
-    SDIST_TAR_NAME = manifest-tool-2.6.0.tar.gz
+    SDIST_TAR_NAME = manifest_tool-2.6.0.tar.gz
 commands =
     {envpython} setup.py egg_info
     {envpython} setup.py sdist


### PR DESCRIPTION
* Change the `SDIST_TAR_NAME` from `manifest-tool-2.6.0.tar.gz` to `manifest_tool-2.6.0.tar.gz`.
* Drop Python 3.7 (it is EOL).
* Run `tox` via `python -m tox` (for Mac compatibility).
