### PR TITLE
Release 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ It is advisable to install the `manifest-tool` Python package within a segregate
 
 **Prerequisites:**
 
-* [Python 3.7 ... 3.11](https://www.python.org/downloads/).
-    * Python 3.12 support is not available yet (it functions on Linux but not on Windows).
+* [Python 3.8 ... 3.11](https://www.python.org/downloads/).
+    * Python 3.12 support is not available yet.
 * [pip (Python Package Installer)](https://pip.pypa.io/en/stable/).
 * Internet connectivity
 
@@ -71,8 +71,7 @@ pip install manifest-tool==2.4.1
 
 **Prerequisites:**
 
-* [Python 3.7 ... 3.11](https://www.python.org/downloads/).
-* [pip (Python Package Installer)](https://pip.pypa.io/en/stable/).
+* In addition to PyPi-installation pre-requisites:
 * Native toolchain:
     * GCC/Clang for Linux/MacOS.
     * [Microsoft Build Tools for Visual Studio 2019](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019) 

--- a/build_manylinux_wheels_entry_point.sh
+++ b/build_manylinux_wheels_entry_point.sh
@@ -37,13 +37,40 @@ function repair_wheel {
     fi
 }
 
-# Compile wheels to wheelhouse/$PLAT
-for PYBIN in /opt/python/cp3*/bin; do
-    # Skip Python 3.5 and 3.6 (too old)
-    if [[ "$PYBIN" == /opt/python/cp35-cp35m/bin ]]; then
-        continue
+# Return 1 if the python version should be skipped
+# Return 0 if the python version shouldn't be skipped
+function skip_not_supported_python_version {
+    pybin="$1"
+    
+    # Skip Python 3.5, 3.6, and 3.7 (too old)
+    if [[ "$pybin" == /opt/python/cp35-cp35m/bin ]]; then
+        return 1
     fi
-    if [[ "$PYBIN" == /opt/python/cp36-cp36m/bin ]]; then
+    if [[ "$pybin" == /opt/python/cp36-cp36m/bin ]]; then
+        return 1
+    fi
+    if [[ "$pybin" == /opt/python/cp37-cp37m/bin ]]; then
+        return 1
+    fi
+    
+    # Skip Python 3.12 and 3.13(not supported yet)
+    if [[ "$pybin" == /opt/python/cp312-cp312/bin ]]; then
+        return 1
+    fi
+    if [[ "$pybin" == /opt/python/cp313-cp313/bin ]]; then
+        return 1
+    fi
+    if [[ "$pybin" == /opt/python/cp313-cp313t/bin ]]; then
+        return 1
+    fi
+    
+    
+    return 0
+}
+
+# Compile wheels to wheelhouse/$PLAT
+for PYBIN in /opt/python/cp3*/bin; do   
+    if ! skip_not_supported_python_version "$PYBIN"; then
         continue
     fi
     echo '------------------------------------------------------------'
@@ -67,12 +94,8 @@ if [ -z "$(ls -A wheelhouse/"$PLAT")" ]; then
 fi
 
 # Install packages and test
-for PYBIN in /opt/python/cp3*/bin; do
-    # Skip Python 3.5 and 3.6 (too old)
-    if [[ $PYBIN == /opt/python/cp35-cp35m/bin ]]; then
-        continue
-    fi
-    if [[ $PYBIN == /opt/python/cp36-cp36m/bin ]]; then
+for PYBIN in /opt/python/cp3*/bin; do   
+    if ! skip_not_supported_python_version "$PYBIN"; then
         continue
     fi
     echo '------------------------------------------------------------'

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.6.1
+- Drop support for Python 3.7.
+    - Python 3.7 is end of life.
+    - It fails the PR-checks in Mac runner as an `arm64`-package of Python 3.7 is not available.
+- Upgrade cryptography dependency from 41.0.4 to latest 42.0.7.
+    - There were multiple CVEs in the earlier one.
+    - However, they do not impact manifest-tool as we do not use pkcs12 functionality.
+
 ## 2.6.0
 - Add support for an external signing tool
    - The feature enables to use of an external signing tool for signing the manifest. 

--- a/dev-README.md
+++ b/dev-README.md
@@ -7,11 +7,11 @@
 
 Example:
 ```shell
+$ pyenv install 3.11.0
 $ pyenv install 3.10.0
 $ pyenv install 3.9.0
 $ pyenv install 3.8.0
-$ pyenv install 3.7.5
-$ pyenv local 3.9.0 3.8.0 3.7.5
+$ pyenv local 3.11.0 3.10.0 3.9.0 3.8.0
 $ python --version
 Python 3.8.0
 ```
@@ -60,7 +60,7 @@ Execute `tox -e py38` to test only the python3.8 environment.
 ## wheel creation
 
 ```shell
-$ pyenv local 3.7.5
+$ pyenv local 3.9.0
 $ python setup.py bdist_wheel
 $ pyenv local 3.8.9
 $ python setup.py bdist_wheel

--- a/manifesttool/__init__.py
+++ b/manifesttool/__init__.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # Copyright 2019-2021 Pelion
-# Copyright (c) 2022 Izuma Networks
+# Copyright 2022-2024 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,4 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML>=6.0,<7.0.0a
 asn1ate>=0.5,<=0.6.0
-cryptography==41.0.4
+cryptography==42.0.7
 jsonschema>=2.6.0,<=3.2.0
 pyasn1>=0.3.1,<=0.4.8
 requests==2.31

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,8 @@ ignore = E302,E203,W503
 skips = B101,B404
 
 [tox]
+requires =
+    tox>=4
 envlist =
     py{38,39,310,311}
     py{38,39,310,311}-x64
@@ -61,7 +63,7 @@ skip_install=True
 deps =
 # FIXME - use '{envpython} setup.py --fullname'
 setenv =
-    SDIST_TAR_NAME = manifest_tool-2.6.0.tar.gz
+    SDIST_TAR_NAME = manifest_tool-2.6.1.tar.gz
 commands =
     {envpython} setup.py egg_info
     {envpython} setup.py sdist


### PR DESCRIPTION
* Drop support for Python 3.7.
  * Python 3.7 is end-of-life.
  *  It fails the PR-checks in Mac runner as an `arm64` - package of Python 3.7 is not available.
* Upgrade cryptography dependency from 41.0.4 to the latest 42.0.7.
  * There were multiple CVEs in the earlier one.
  * However, they do not impact manifest-tool as we do not use pkcs12 functionality.